### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -1,5 +1,12 @@
 package main
 
+func obfuscateToken(token string) string {
+	if len(token) > 10 {
+		return token[:10] + "..."
+	}
+	return token
+}
+
 import (
 	"encoding/json"
 	"fmt"
@@ -660,7 +667,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token %s", obfuscateToken(authz))
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Potential fix for [https://github.com/andreileontesag/malaga-workshop-ghas/security/code-scanning/4](https://github.com/andreileontesag/malaga-workshop-ghas/security/code-scanning/4)

To fix the issue, we should avoid logging the sensitive `authz` value directly. Instead, we can log a sanitized or obfuscated version of the token, such as only the first few characters followed by an ellipsis. This approach allows for debugging while protecting sensitive information. Additionally, we should review other logging statements in the function to ensure no sensitive data is exposed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
